### PR TITLE
Added support for IAsyncAction

### DIFF
--- a/PoshWinRT/AsyncActionWrapper.cs
+++ b/PoshWinRT/AsyncActionWrapper.cs
@@ -1,26 +1,29 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using Windows.Foundation;
 
 namespace PoshWinRT
 {
-    public class AsyncOperationWrapper<T> : AsyncInfoWrapper<IAsyncOperation<T>>
+    public class AsyncActionWrapper : AsyncInfoWrapper<IAsyncAction>
     {
-        public AsyncOperationWrapper(object asyncOperation) : base(asyncOperation) { }
+        public AsyncActionWrapper(object asyncAction) : base(asyncAction) { }
 
-        public object AwaitResult()
+        public void AwaitResult()
         {
-            return AwaitResult(-1);
+            AwaitResult(-1);
         }
 
-        public object AwaitResult(int millisecondsTimeout)
+        public void AwaitResult(int millisecondsTimeout)
         {
             var task = _asyncInfo.AsTask();
             task.Wait(millisecondsTimeout);
 
             if (task.IsCompleted)
             {
-                return task.Result;
+                return;
             }
             else if (task.IsFaulted)
             {
@@ -31,5 +34,6 @@ namespace PoshWinRT
                 throw new TaskCanceledException(task);
             }
         }
+
     }
 }

--- a/PoshWinRT/AsyncInfoWrapper.cs
+++ b/PoshWinRT/AsyncInfoWrapper.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.Foundation;
+
+namespace PoshWinRT
+{
+    public abstract class AsyncInfoWrapper<T> : IDisposable where T : IAsyncInfo
+    {
+        protected T _asyncInfo;
+
+        public AsyncInfoWrapper(object asyncInfo)
+        {
+            if (asyncInfo == null) throw new ArgumentNullException("asyncInfo");
+
+            _asyncInfo = (T)asyncInfo;
+        }
+
+        ~AsyncInfoWrapper()
+        {
+            GC.SuppressFinalize(this);
+            this.Dispose(false);
+        }
+
+        public void Dispose()
+        {
+            this.Dispose(true);
+        }
+
+        private void Dispose(bool disposing)
+        {
+            if (_asyncInfo == null) return;
+
+            if (disposing)
+            {
+                _asyncInfo.Close();
+                _asyncInfo = default(T);
+            }
+        }
+
+        public AsyncStatus Status
+        {
+            get { return _asyncInfo.Status; }
+        }
+
+    }
+
+}
+

--- a/PoshWinRT/PoshWinRT.csproj
+++ b/PoshWinRT/PoshWinRT.csproj
@@ -49,6 +49,8 @@
     <Reference Include="Windows" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AsyncActionWrapper.cs" />
+    <Compile Include="AsyncInfoWrapper.cs" />
     <Compile Include="AsyncOperationWrapper.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>


### PR DESCRIPTION
I had some issues running the Set-LockscreenWallpaper function by @Sauler [here](https://github.com/Sauler/PowershellUtils), which uses this class. That powershell function needed a final `AwaitResult()` call at the end, which required support for the WinRT interface `IAsyncAction` instead of `IAsyncOperator<T>` . This PR adds support for `IAsyncAction` (and moves some logic into a common parent abstract class). Best I can tell, it is working when added to Set-LockscreenWallpaper.

My C#/Windows knowledge is fairly limited, so it's possible I did something Java-ish.